### PR TITLE
Introduce CONTROLLER_NAMESPACED flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@
 This controller manage Keycloak clients and realms over Kubernetes resources and creates a Kubernetes secret with 
 the `clientSecret` for clients of type `confidential`.
 
-Within the cluster, multiple Keycloak instances can be referenced. This become useful in a multi-tenant environment where different services
+Within the cluster, multiple Keycloak instances can be referenced.
+This become useful in a multi-tenant environment where different services
 has to be registered at different Keycloak instances.
+
+By default, the controller watches only for events in its namespace.
+To enable watching in all namespaces set environment variable `CONTROLLER_NAMESPACED=false`.
  
 ## Setup
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<version.resteasy>3.6.3.Final</version.resteasy>
 		<version.logback>1.2.3</version.logback>
 		<version.logback-contrib>0.1.5</version.logback-contrib>
-		<version.k8s-client>4.2.0</version.k8s-client>
+		<version.k8s-client>4.3.1</version.k8s-client>
 		<version.lombok>1.18.8</version.lombok>
 		<version.com.spotify.ile>1.4.10</version.com.spotify.ile>
 

--- a/src/main/java/com/kiwigrid/keycloak/controller/KubernetesController.java
+++ b/src/main/java/com/kiwigrid/keycloak/controller/KubernetesController.java
@@ -7,6 +7,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.*;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
+import io.micronaut.context.annotation.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +17,9 @@ public abstract class KubernetesController<T extends CustomResource> implements 
 	protected final KubernetesClient kubernetes;
 	protected final Map<String, T> resources = new HashMap<>();
 	protected final MixedOperation<T, ? extends CustomResourceList<T>, ?, ?> customResources;
+
+	@Value("${controller.namespaced:true}")
+	protected boolean namespaced;
 
 	protected KubernetesController(KubernetesClient kubernetes,
 			CustomResourceDefinition crd,
@@ -39,7 +43,10 @@ public abstract class KubernetesController<T extends CustomResource> implements 
 
 	public Watch watch() {
 		log.trace("Start watcher.");
-		return customResources.watch(this);
+		if(namespaced) {
+			return customResources.watch(this);
+		}
+		return customResources.inAnyNamespace().watch(this);
 	}
 
 	@Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,7 @@ endpoints:
 logging.level:
   com.kiwigrid: TRACE
   io.fabric8.kubernetes.client.internal.VersionUsageUtils: ERROR
+
+controller:
+  ## Controls whether controller watch only for events in its namespace
+  namespaced: true


### PR DESCRIPTION
By default, the controller watches only for events in its namespace.
To enable watching in all namespaces set environment variable `CONTROLLER_NAMESPACED=false`.