### PR TITLE
Enable the user to bind the client to realm roles directly

### DIFF
--- a/examples/client-mappers-roles.yaml
+++ b/examples/client-mappers-roles.yaml
@@ -18,6 +18,8 @@ spec:
         - service
         - admin
         - grandmaster
+  serviceAccountRealmRoles:
+    - editor
   mapper:
     - name: audience
       protocolMapper: oidc-audience-mapper

--- a/src/main/java/com/kiwigrid/keycloak/controller/client/ClientResource.java
+++ b/src/main/java/com/kiwigrid/keycloak/controller/client/ClientResource.java
@@ -60,6 +60,7 @@ public class ClientResource extends CustomResource {
 		private String secretKey = "secret";
 		private List<ClientMapper> mapper = new ArrayList<>();
 		private List<ClientRole> roles = new ArrayList<>();
+		private List<String> serviceAccountRealmRoles = new ArrayList<>();
 	}
 
 	@lombok.Getter


### PR DESCRIPTION
Using the 'roles' key would create a new client role that would be wrapped in the listed realm roles as composites. This enable
us to define a new role and grant it so, let's say, all admins in the system. But this does not enable us to define that a given
client has to receive a given realm role in order to operate. This new feature now enables the later.

This is important so we can have automated/reproducible keycloak realm configuration