### PR TITLE
Client Scope CRD does not match Java implementation

### DIFF
--- a/src/main/java/com/kiwigrid/keycloak/controller/clientscope/ClientScopeController.java
+++ b/src/main/java/com/kiwigrid/keycloak/controller/clientscope/ClientScopeController.java
@@ -56,7 +56,7 @@ public class ClientScopeController extends KubernetesController<ClientScopeResou
 			if (optionalClientScopeRepresentation.isEmpty()) {
 				ClientScopeRepresentation clientRepresentation = new ClientScopeRepresentation();
 				clientRepresentation.setProtocol("openid-connect");
-				clientRepresentation.setId(clientScopeName);
+				clientRepresentation.setName(clientScopeName);
 				map(clientScopeResource.getSpec(), clientRepresentation, true);
 				clientUuid = getId(clientScopesResource.create(clientRepresentation));
 				log.info("{}/{}/{}: created client scope", keycloak, realmName, clientScopeName);

--- a/src/main/k8s/client-scope.yaml
+++ b/src/main/k8s/client-scope.yaml
@@ -74,14 +74,7 @@ spec:
                       type: string
             attributes:
               description: 'Client scope attributes'
-              type: array
-              items:
-                type: object
-                properties:
-                  key:
-                    type: string
-                  value:
-                    type: string
+              type: object
         status:
           type: object
           required:


### PR DESCRIPTION
The `ClientScopeResource` Java class uses a `Map<String,String>` for the `attributes` field, but the CRD defines it as an array of key/value pairs.
Thus, defining the `attributes` field in a client scope resource causes keycloak-controller to fail.

This changes the CRD to define `attributes` as an object rather than an array.