### PR TITLE
Ignoring role name case on service account role synchronization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,14 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.20.2</version>
+			<scope>test</scope>
+		</dependency>
+
+
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>${version.mockito}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,6 @@
 			<scope>test</scope>
 		</dependency>
 
-
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>

--- a/src/main/java/com/kiwigrid/keycloak/controller/client/ClientController.java
+++ b/src/main/java/com/kiwigrid/keycloak/controller/client/ClientController.java
@@ -30,15 +30,18 @@ public class ClientController extends KubernetesController<ClientResource> {
 
 	final KeycloakController keycloak;
 	final AssignedClientScopesSyncer assignedClientScopesSyncer;
+	final ServiceAccountRoleAssignmentSynchronizer serviceAccountRoleAssignmentSynchronizer;
 
 	public ClientController(KeycloakController keycloak,
 			KubernetesClient kubernetes,
-			AssignedClientScopesSyncer assignedClientScopesSyncer) {
+			AssignedClientScopesSyncer assignedClientScopesSyncer,
+			ServiceAccountRoleAssignmentSynchronizer serviceAccountRoleAssignmentSynchronizer) {
 
 		super(kubernetes, ClientResource.DEFINITION, ClientResource.class, ClientResource.ClientResourceList.class,
 				ClientResource.ClientResourceDoneable.class);
 		this.keycloak = keycloak;
 		this.assignedClientScopesSyncer = assignedClientScopesSyncer;
+		this.serviceAccountRoleAssignmentSynchronizer = serviceAccountRoleAssignmentSynchronizer;
 	}
 
 	@Override
@@ -364,57 +367,9 @@ public class ClientController extends KubernetesController<ClientResource> {
 	}
 
 	private void manageServiceAccountRealmRoles(RealmResource realmResource, String clientUuid, ClientResource clientResource) {
-		var keycloak = clientResource.getSpec().getKeycloak();
-		var realm = clientResource.getSpec().getRealm();
-		var clientId = clientResource.getSpec().getClientId();
 
-		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = realmResource.clients().get(clientUuid);
-		RoleMappingResource serviceAccountRolesMapping = realmResource.users()
-				.get(keycloakClientResource.getServiceAccountUser().getId())
-				.roles();
+		this.serviceAccountRoleAssignmentSynchronizer.manageServiceAccountRealmRoles(realmResource, clientResource, clientUuid);
 
-		List<String> requestedRealmRoles = clientResource.getSpec().getServiceAccountRealmRoles();
-
-		removeRoleMappingNotRequestedAnymore(keycloak, realm, clientId, serviceAccountRolesMapping, requestedRealmRoles);
-
-		List<String> realmRoleNames = realmResource.roles().list().stream().map(RoleRepresentation::getName).collect(Collectors.toList());
-		List<String> rolesToCreate = requestedRealmRoles.stream().filter(role -> !realmRoleNames.contains(role)).collect(Collectors.toList());
-		createRolesInRealm(keycloak, realm, clientId, realmResource.roles(), rolesToCreate);
-
-		List<RoleRepresentation> rolesToBind = realmResource.roles().list().stream()
-				.filter(roleInRealm -> requestedRealmRoles.contains(roleInRealm.getName()))
-				.collect(Collectors.toList());
-
-		serviceAccountRolesMapping
-				.realmLevel()
-				.add(rolesToBind);
-	}
-
-	private void createRolesInRealm(String keycloak, String realm, String clientId, RolesResource rolesResource, List<String> rolesToCreate) {
-		for (String roleToCreate : rolesToCreate) {
-			var representation = new RoleRepresentation();
-			representation.setName(roleToCreate);
-			representation.setClientRole(false);
-			representation.setComposite(false);
-			rolesResource.create(representation);
-			log.info("{}/{}/{}: created realm role {}", keycloak, realm, clientId, roleToCreate);
-		}
-	}
-
-	private void removeRoleMappingNotRequestedAnymore(String keycloak, String realm, String clientId, RoleMappingResource serviceAccountRoleMapping, List<String> requestedRealmRoles) {
-		List rolesToRemove = new ArrayList();
-
-		List<RoleRepresentation> currentlyMappedRealmRoles = serviceAccountRoleMapping.getAll().getRealmMappings();
-		for (RoleRepresentation currentlyMappedRole : currentlyMappedRealmRoles) {
-			if (!requestedRealmRoles.contains(currentlyMappedRole.getName())) {
-				rolesToRemove.add(currentlyMappedRole);
-				log.info("{}/{}/{}: deleted role not requested anymore {}",
-						keycloak, realm, clientId, currentlyMappedRole.getName());
-			}
-		}
-		serviceAccountRoleMapping
-				.realmLevel()
-				.remove(rolesToRemove);
 	}
 
 	private void manageRoles(RealmResource realmResource, String clientUuid, ClientResource clientResource) {

--- a/src/main/java/com/kiwigrid/keycloak/controller/client/ClientController.java
+++ b/src/main/java/com/kiwigrid/keycloak/controller/client/ClientController.java
@@ -2,7 +2,6 @@ package com.kiwigrid.keycloak.controller.client;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
@@ -19,8 +18,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.keycloak.admin.client.resource.RealmResource;
-import org.keycloak.admin.client.resource.RoleMappingResource;
-import org.keycloak.admin.client.resource.RolesResource;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
@@ -97,6 +94,7 @@ public class ClientController extends KubernetesController<ClientResource> {
 
 			if (clientResource.getSpec().getServiceAccountsEnabled() == Boolean.TRUE) {
 				manageServiceAccountRealmRoles(realmResource, clientUuid, clientResource);
+
 			}
 			updateStatus(clientResource, null);
 		} catch (RuntimeException e) {
@@ -368,7 +366,7 @@ public class ClientController extends KubernetesController<ClientResource> {
 
 	private void manageServiceAccountRealmRoles(RealmResource realmResource, String clientUuid, ClientResource clientResource) {
 
-		this.serviceAccountRoleAssignmentSynchronizer.manageServiceAccountRealmRoles(realmResource, clientResource, clientUuid);
+		this.serviceAccountRoleAssignmentSynchronizer.synchronizeServiceAccountRealmRoles(realmResource, clientResource, clientUuid);
 
 	}
 

--- a/src/main/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignment.java
+++ b/src/main/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignment.java
@@ -1,0 +1,99 @@
+package com.kiwigrid.keycloak.controller.client;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RoleMappingResource;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ServiceAccountRoleAssignment {
+	private final Logger LOG = LoggerFactory.getLogger(getClass());
+
+	public List<RoleRepresentation> findAssignedRolesToRemoveWith(RealmResource realmResource,
+			ClientResource clientResource, String clientUuid)
+	{
+		List<RoleRepresentation> assignedServiceAccountRoles = getAssignedServiceAccountRoles(
+				realmResource,
+				clientUuid);
+		List<String> requestedServiceAccountRoleNames = getRequestedServiceAccountRoleNamesFrom(
+				clientResource);
+
+		return assignedServiceAccountRoles
+				.stream()
+				.filter(roleRepresentation -> !requestedServiceAccountRoleNames
+						.stream()
+						.anyMatch(roleName -> roleName.equalsIgnoreCase(roleRepresentation.getName())))
+				.collect(Collectors.toList());
+	}
+
+	private List<String> getRequestedServiceAccountRoleNamesFrom(ClientResource clientResourceDefinition) {
+		return clientResourceDefinition
+				.getSpec()
+				.getServiceAccountRealmRoles();
+	}
+
+	private List<RoleRepresentation> getAssignedServiceAccountRoles(RealmResource realmResource, String clientUuid) {
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = realmResource.clients()
+				.get(clientUuid);
+		return realmResource.users()
+				.get(keycloakClientResource.getServiceAccountUser().getId())
+				.roles().getAll().getRealmMappings();
+	}
+
+	public List<RoleRepresentation> findRolesToAssignWith(RealmResource realmResource,
+			ClientResource clientResourceDefinition, String clientUuid)
+	{
+		List<RoleRepresentation> assignedServiceAccountRoles = getAssignedServiceAccountRoles(
+				realmResource,
+				clientUuid);
+		List<String> requestedServiceAccountRoleNames = getRequestedServiceAccountRoleNamesFrom(
+				clientResourceDefinition);
+		List<RoleRepresentation> serviceAccountRealmRoles = realmResource.roles().list();
+
+		var unassignedRequestedRoleNames = requestedServiceAccountRoleNames.stream()
+				.filter(roleName -> !assignedServiceAccountRoles.stream()
+						.anyMatch(roleRepresentation -> roleName.equalsIgnoreCase(roleRepresentation.getName())))
+				.collect(Collectors.toList());
+
+		return serviceAccountRealmRoles.stream()
+				.filter(roleRepresentation -> unassignedRequestedRoleNames.stream()
+						.anyMatch(roleName -> roleRepresentation.getName().equalsIgnoreCase(roleName)))
+				.collect(Collectors.toList());
+	}
+
+	public List<RoleRepresentation> findRequestedRolesToCreateWith(RealmResource realmResource,
+			ClientResource clientResourceDefinition)
+	{
+		List<RoleRepresentation> serviceAccountRealmRoleMappings = realmResource.roles().list();
+
+		return getRequestedServiceAccountRoleNamesFrom(clientResourceDefinition)
+				.stream()
+				.filter(roleName -> !serviceAccountRealmRoleMappings
+						.stream()
+						.anyMatch(roleRepresentation -> roleRepresentation
+								.getName()
+								.equalsIgnoreCase(roleName)))
+				.map(this::createRoleRepresentation)
+				.collect(Collectors.toList());
+	}
+
+	RoleRepresentation createRoleRepresentation(String roleName) {
+		var roleRepresentation = new RoleRepresentation();
+		roleRepresentation.setName(roleName);
+		roleRepresentation.setClientRole(false);
+		roleRepresentation.setComposite(false);
+		return roleRepresentation;
+	}
+
+	public RoleMappingResource getServiceAccountRoleMappingsFor(RealmResource realmResource, String clientUuid) {
+		return realmResource.users()
+				.get(realmResource
+						.clients()
+						.get(clientUuid)
+						.getServiceAccountUser()
+						.getId()).roles();
+	}
+}

--- a/src/main/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignment.java
+++ b/src/main/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignment.java
@@ -3,12 +3,14 @@ package com.kiwigrid.keycloak.controller.client;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.inject.Singleton;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RoleMappingResource;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Singleton
 public class ServiceAccountRoleAssignment {
 	private final Logger LOG = LoggerFactory.getLogger(getClass());
 

--- a/src/main/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentSynchronizer.java
+++ b/src/main/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentSynchronizer.java
@@ -1,0 +1,100 @@
+package com.kiwigrid.keycloak.controller.client;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Singleton;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RoleMappingResource;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class ServiceAccountRoleAssignmentSynchronizer {
+	private final Logger LOG = LoggerFactory.getLogger(getClass());
+	private final ServiceAccountRoleAssignment serviceAccountRoleAssignment;
+
+	public ServiceAccountRoleAssignmentSynchronizer(ServiceAccountRoleAssignment serviceAccountRoleAssignment) {
+		this.serviceAccountRoleAssignment = serviceAccountRoleAssignment;
+	}
+
+	public void manageServiceAccountRealmRoles(RealmResource realmResource, ClientResource clientResourceDefinition, String clientUuid) {
+		var keycloak = clientResourceDefinition.getSpec().getKeycloak();
+		var realm = clientResourceDefinition.getSpec().getRealm();
+		var clientId = clientResourceDefinition.getSpec().getClientId();
+
+		RoleMappingResource serviceAccountRoleMappings = serviceAccountRoleAssignment.getServiceAccountRoleMappingsFor(
+				realmResource,
+				clientUuid);
+
+		List<RoleRepresentation> assignedServiceAccountRolesToRemove = serviceAccountRoleAssignment
+				.findAssignedRolesToRemoveWith(
+						realmResource,
+						clientResourceDefinition,
+						clientUuid);
+
+		if (!assignedServiceAccountRolesToRemove.isEmpty()) {
+			removeAssignedRolesFromServiceAccount(keycloak,
+					realm,
+					clientId,
+					serviceAccountRoleMappings,
+					assignedServiceAccountRolesToRemove);
+		}
+
+		List<RoleRepresentation> serviceAccountRealmRolesToCreate = serviceAccountRoleAssignment
+				.findRequestedRolesToCreateWith(
+						realmResource,
+						clientResourceDefinition);
+
+		if (!serviceAccountRealmRolesToCreate.isEmpty()) {
+			createNewRealmRoles(realmResource, keycloak, realm, clientId, serviceAccountRealmRolesToCreate);
+		}
+
+		List<RoleRepresentation> serviceAccountRolesToAssign = serviceAccountRoleAssignment
+				.findRolesToAssignWith(
+						realmResource,
+						clientResourceDefinition,
+						clientUuid);
+
+		if (!serviceAccountRolesToAssign.isEmpty()) {
+			assignRequestedRolesToServiceAccount(keycloak,
+					realm,
+					clientId,
+					serviceAccountRoleMappings,
+					serviceAccountRolesToAssign);
+		}
+	}
+
+	private void removeAssignedRolesFromServiceAccount(String keycloak, String realm, String clientId, RoleMappingResource serviceAccountRoleMappings, List<RoleRepresentation> assignedServiceAccountRolesToRemove) {
+		serviceAccountRoleMappings.realmLevel().remove(assignedServiceAccountRolesToRemove);
+		LOG.info("{}/{}/{}: deleted roles not requested anymore {}",
+				keycloak,
+				realm,
+				clientId,
+				assignedServiceAccountRolesToRemove.stream()
+						.map(RoleRepresentation::getName)
+						.collect(Collectors.toList()));
+	}
+
+	private void createNewRealmRoles(RealmResource realmResource, String keycloak, String realm, String clientId, List<RoleRepresentation> serviceAccountRealmRolesToCreate) {
+		serviceAccountRealmRolesToCreate.stream()
+				.forEach(roleRepresentation -> realmResource.roles().create(roleRepresentation));
+		LOG.info("{}/{}/{}: created realm roles {}",
+				keycloak,
+				realm,
+				clientId,
+				serviceAccountRealmRolesToCreate.stream()
+						.map(RoleRepresentation::getName)
+						.collect(Collectors.toList()));
+	}
+
+	private void assignRequestedRolesToServiceAccount(String keycloak, String realm, String clientId, RoleMappingResource serviceAccountRoleMappings, List<RoleRepresentation> serviceAccountRolesToAssign) {
+		serviceAccountRoleMappings.realmLevel().add(serviceAccountRolesToAssign);
+		LOG.info("{}/{}/{}: assigned realm roles {}",
+				keycloak,
+				realm,
+				clientId,
+				serviceAccountRolesToAssign.stream().map(RoleRepresentation::getName).collect(Collectors.toList()));
+	}
+}

--- a/src/main/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentSynchronizer.java
+++ b/src/main/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentSynchronizer.java
@@ -19,7 +19,7 @@ public class ServiceAccountRoleAssignmentSynchronizer {
 		this.serviceAccountRoleAssignment = serviceAccountRoleAssignment;
 	}
 
-	public void manageServiceAccountRealmRoles(RealmResource realmResource, ClientResource clientResourceDefinition, String clientUuid) {
+	public void synchronizeServiceAccountRealmRoles(RealmResource realmResource, ClientResource clientResourceDefinition, String clientUuid) {
 		var keycloak = clientResourceDefinition.getSpec().getKeycloak();
 		var realm = clientResourceDefinition.getSpec().getRealm();
 		var clientId = clientResourceDefinition.getSpec().getClientId();

--- a/src/test/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentMocks.java
+++ b/src/test/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentMocks.java
@@ -1,0 +1,85 @@
+package com.kiwigrid.keycloak.controller.client;
+
+import java.util.List;
+
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RoleMappingResource;
+import org.keycloak.admin.client.resource.RoleScopeResource;
+import org.keycloak.admin.client.resource.RolesResource;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.representations.idm.MappingsRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+
+public class ServiceAccountRoleAssignmentMocks {
+	org.keycloak.admin.client.resource.ClientResource createKeycloakClientResourceMock() {
+		var keycloakClientResource = Mockito.mock(org.keycloak.admin.client.resource.ClientResource.class);
+		var userRepresentation = Mockito.mock(UserRepresentation.class);
+
+		given(keycloakClientResource.getServiceAccountUser())
+				.willReturn(userRepresentation);
+		given(userRepresentation.getId())
+				.willReturn("some-keycloak-service-account-user-id");
+		given(keycloakClientResource.getServiceAccountUser())
+				.willReturn(userRepresentation);
+
+		return keycloakClientResource;
+	}
+
+	RealmResource createKeycloakRealmResourceMockWith(
+			org.keycloak.admin.client.resource.ClientResource keycloakClientResource,
+			List<RoleRepresentation> serviceAccountRolesToAssign,
+			List<RoleRepresentation> serviceAccountRealmRoles)
+	{
+		var keycloakRealmResource = Mockito.mock(RealmResource.class);
+		var keycloakClientsResource = Mockito.mock(ClientsResource.class);
+		var keycloakUsersResource = Mockito.mock(UsersResource.class);
+		var keycloakUserResource = Mockito.mock(UserResource.class);
+		var keycloakRolesResource = Mockito.mock(RolesResource.class);
+		var keycloakRoleMappingResource = Mockito.mock(RoleMappingResource.class);
+		var keycloakRoleMappingsRepresentation = Mockito.mock(MappingsRepresentation.class);
+		var keycloakRoleScopeResource = Mockito.mock(RoleScopeResource.class);
+
+		given(keycloakRealmResource.clients())
+				.willReturn(keycloakClientsResource);
+		given(keycloakClientsResource.get(anyString()))
+				.willReturn(keycloakClientResource);
+		given(keycloakRealmResource.users())
+				.willReturn(keycloakUsersResource);
+		given(keycloakUsersResource.get(anyString()))
+				.willReturn(keycloakUserResource);
+		given(keycloakUserResource.roles())
+				.willReturn(keycloakRoleMappingResource);
+		given(keycloakRoleMappingResource.getAll())
+				.willReturn(keycloakRoleMappingsRepresentation);
+		given(keycloakRoleMappingResource.realmLevel())
+				.willReturn(keycloakRoleScopeResource);
+		given(keycloakRoleMappingsRepresentation.getRealmMappings())
+				.willReturn(serviceAccountRolesToAssign);
+		given(keycloakRealmResource.roles())
+				.willReturn(keycloakRolesResource);
+		given(keycloakRolesResource.list())
+				.willReturn(serviceAccountRealmRoles);
+
+		doAnswer(invocationOnMock -> {
+			RoleRepresentation roleRepresentation = invocationOnMock.getArgument(0);
+			return serviceAccountRealmRoles.add(roleRepresentation);
+		}).when(keycloakRolesResource).create(any(RoleRepresentation.class));
+
+		doAnswer(invocationOnMock -> {
+			List<RoleRepresentation> roleRepresentations = invocationOnMock.getArgument(0);
+			return serviceAccountRolesToAssign.addAll(roleRepresentations);
+		}).when(keycloakRoleScopeResource).add(anyList());
+
+		return keycloakRealmResource;
+	}
+}

--- a/src/test/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentSynchronizerTest.java
+++ b/src/test/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentSynchronizerTest.java
@@ -1,0 +1,146 @@
+package com.kiwigrid.keycloak.controller.client;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RoleMappingResource;
+import org.keycloak.admin.client.resource.RoleScopeResource;
+import org.keycloak.admin.client.resource.RolesResource;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class ServiceAccountRoleAssignmentSynchronizerTest {
+
+	private static final ServiceAccountRoleAssignmentTestObjects testObjects = new ServiceAccountRoleAssignmentTestObjects();
+	private static final String CLIENT_UUID = "some-client-uuid";
+
+	@Test
+	public void givenAssignedRolesAreNotUnassignedAndCreatedAndReassignedIgnoringCase() {
+		// Arrange
+		List<String> serviceAccountRoleNamesToAssign = List.of("hero", "CITIZEN");
+		com.kiwigrid.keycloak.controller.client.ClientResource k8sClientResourceDefinition = testObjects
+				.createK8sClientResourceWith(serviceAccountRoleNamesToAssign);
+
+		var realmResource = mock(RealmResource.class);
+		var rolesResource = mock(RolesResource.class);
+		when(realmResource.roles()).thenReturn(rolesResource);
+
+		var roleMappingResource = mock(RoleMappingResource.class);
+		var roleScopeResource = mock(RoleScopeResource.class);
+		when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
+
+		ServiceAccountRoleAssignment serviceAccountRoleAssignment = mock(ServiceAccountRoleAssignment.class);
+		when(serviceAccountRoleAssignment.getServiceAccountRoleMappingsFor(realmResource, CLIENT_UUID))
+				.thenReturn(roleMappingResource);
+		when(serviceAccountRoleAssignment.findAssignedRolesToRemoveWith(realmResource,
+				k8sClientResourceDefinition,
+				CLIENT_UUID)).thenReturn(Collections.emptyList());
+		when(serviceAccountRoleAssignment.findRolesToAssignWith(realmResource,
+				k8sClientResourceDefinition,
+				CLIENT_UUID)).thenReturn(Collections.emptyList());
+		when(serviceAccountRoleAssignment.findRequestedRolesToCreateWith(realmResource,
+				k8sClientResourceDefinition)).thenReturn(
+				Collections.emptyList());
+
+		ServiceAccountRoleAssignmentSynchronizer synchronizer = new ServiceAccountRoleAssignmentSynchronizer(
+				serviceAccountRoleAssignment);
+
+		// Act
+		synchronizer.manageServiceAccountRealmRoles(realmResource, k8sClientResourceDefinition, CLIENT_UUID);
+
+		// Assert/Verify
+		verifyNoInteractions(rolesResource, roleScopeResource);
+	}
+
+	@Test
+	public void givenUnassignedRoleToAssignThatDoesNotExistInRealmIsCreatedAndAssignedIgnoringCase() {
+		// Arrange
+		var serviceAccountRoleAssignment = mock(ServiceAccountRoleAssignment.class);
+
+		var realmResource = mock(RealmResource.class);
+		var rolesResource = mock(RolesResource.class);
+		when(realmResource.roles()).thenReturn(rolesResource);
+
+		var roleMappingResource = mock(RoleMappingResource.class);
+		var roleScopeResource = mock(RoleScopeResource.class);
+		when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
+
+		var k8sClientResource = testObjects.createK8sClientResourceWith(List.of("CITIZEN", "HERO"));
+
+		when(serviceAccountRoleAssignment.getServiceAccountRoleMappingsFor(realmResource, CLIENT_UUID))
+				.thenReturn(roleMappingResource);
+		when(serviceAccountRoleAssignment.findAssignedRolesToRemoveWith(realmResource, k8sClientResource, CLIENT_UUID))
+				.thenReturn(Collections.emptyList());
+
+		List<RoleRepresentation> rolesToAdd = testObjects.toRoleRepresentations(List.of("HERO"));
+		when(serviceAccountRoleAssignment.findRequestedRolesToCreateWith(realmResource, k8sClientResource))
+				.thenReturn(rolesToAdd);
+		when(serviceAccountRoleAssignment.findRolesToAssignWith(realmResource, k8sClientResource, CLIENT_UUID))
+				.thenReturn(rolesToAdd);
+
+		var synchronizer = new ServiceAccountRoleAssignmentSynchronizer(serviceAccountRoleAssignment);
+
+		// Act
+		synchronizer.manageServiceAccountRealmRoles(realmResource, k8sClientResource, CLIENT_UUID);
+
+		// Assert
+		InOrder inOrder = Mockito.inOrder(roleScopeResource, rolesResource);
+
+		inOrder.verify(roleScopeResource, times(0)).remove(anyList());
+		inOrder.verify(rolesResource).create(rolesToAdd.get(0));
+		inOrder.verify(roleScopeResource).add(rolesToAdd);
+		inOrder.verifyNoMoreInteractions();
+	}
+
+	@Test
+	public void givenUnassignedRoleToAssignThatExistsInRealmIsNotCreatedButAssignedIgnoringCase() {
+		// Arrange
+		ServiceAccountRoleAssignment serviceAccountRoleAssignment = mock(ServiceAccountRoleAssignment.class);
+		List<String> serviceAccountRoleNamesToAssign = List.of("CITIZEN", "hero");
+		List<RoleRepresentation> serviceAccountRolesToAssign = testObjects
+				.toRoleRepresentations(serviceAccountRoleNamesToAssign);
+		com.kiwigrid.keycloak.controller.client.ClientResource k8sClientResourceDefinition = testObjects
+				.createK8sClientResourceWith(serviceAccountRoleNamesToAssign);
+
+		var realmResource = mock(RealmResource.class);
+		var rolesResource = mock(RolesResource.class);
+		when(realmResource.roles()).thenReturn(rolesResource);
+
+		var roleMappingResource = mock(RoleMappingResource.class);
+		var roleScopeResource = mock(RoleScopeResource.class);
+		when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
+
+		when(serviceAccountRoleAssignment.getServiceAccountRoleMappingsFor(realmResource, CLIENT_UUID))
+				.thenReturn(roleMappingResource);
+		when(serviceAccountRoleAssignment.findRolesToAssignWith(realmResource,
+				k8sClientResourceDefinition,
+				CLIENT_UUID)).thenReturn(serviceAccountRolesToAssign);
+		when(serviceAccountRoleAssignment.findAssignedRolesToRemoveWith(realmResource,
+				k8sClientResourceDefinition,
+				CLIENT_UUID)).thenReturn(Collections.emptyList());
+		when(serviceAccountRoleAssignment.findRequestedRolesToCreateWith(realmResource,
+				k8sClientResourceDefinition)).thenReturn(Collections.emptyList());
+
+		ServiceAccountRoleAssignmentSynchronizer synchronizer = new ServiceAccountRoleAssignmentSynchronizer(
+				serviceAccountRoleAssignment);
+
+		// Act
+		synchronizer.manageServiceAccountRealmRoles(realmResource, k8sClientResourceDefinition, CLIENT_UUID);
+
+		InOrder inOrder = Mockito.inOrder(roleScopeResource, rolesResource);
+		inOrder.verify(roleScopeResource, times(0)).remove(anyList());
+		inOrder.verify(rolesResource, times(0)).create(any(RoleRepresentation.class));
+		inOrder.verify(roleScopeResource).add(serviceAccountRolesToAssign);
+		inOrder.verifyNoMoreInteractions();
+	}
+}

--- a/src/test/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentSynchronizerTest.java
+++ b/src/test/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentSynchronizerTest.java
@@ -56,7 +56,7 @@ public class ServiceAccountRoleAssignmentSynchronizerTest {
 				serviceAccountRoleAssignment);
 
 		// Act
-		synchronizer.manageServiceAccountRealmRoles(realmResource, k8sClientResourceDefinition, CLIENT_UUID);
+		synchronizer.synchronizeServiceAccountRealmRoles(realmResource, k8sClientResourceDefinition, CLIENT_UUID);
 
 		// Assert/Verify
 		verifyNoInteractions(rolesResource, roleScopeResource);
@@ -91,7 +91,7 @@ public class ServiceAccountRoleAssignmentSynchronizerTest {
 		var synchronizer = new ServiceAccountRoleAssignmentSynchronizer(serviceAccountRoleAssignment);
 
 		// Act
-		synchronizer.manageServiceAccountRealmRoles(realmResource, k8sClientResource, CLIENT_UUID);
+		synchronizer.synchronizeServiceAccountRealmRoles(realmResource, k8sClientResource, CLIENT_UUID);
 
 		// Assert
 		InOrder inOrder = Mockito.inOrder(roleScopeResource, rolesResource);
@@ -135,7 +135,7 @@ public class ServiceAccountRoleAssignmentSynchronizerTest {
 				serviceAccountRoleAssignment);
 
 		// Act
-		synchronizer.manageServiceAccountRealmRoles(realmResource, k8sClientResourceDefinition, CLIENT_UUID);
+		synchronizer.synchronizeServiceAccountRealmRoles(realmResource, k8sClientResourceDefinition, CLIENT_UUID);
 
 		InOrder inOrder = Mockito.inOrder(roleScopeResource, rolesResource);
 		inOrder.verify(roleScopeResource, times(0)).remove(anyList());

--- a/src/test/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentTest.java
+++ b/src/test/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentTest.java
@@ -1,0 +1,326 @@
+package com.kiwigrid.keycloak.controller.client;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServiceAccountRoleAssignmentTest {
+
+	private static final String SOME_CLIENT_UUID = "some-client-uuid";
+	private static final ServiceAccountRoleAssignmentTestObjects testObjects = new ServiceAccountRoleAssignmentTestObjects();
+	private static final ServiceAccountRoleAssignmentMocks mocks = new ServiceAccountRoleAssignmentMocks();
+
+	@Test
+	public void noRoleFoundForRemovalWhenLowerCaseRoleNamesEqualGivenUpperCaseRoleNames() {
+		// Arrange
+		List<RoleRepresentation> assignedServiceAccountRoleMappings = testObjects.toRoleRepresentations(List
+				.of("hero", "criminal"));
+		List<RoleRepresentation> serviceAccountRealmRoleMappings = testObjects.toRoleRepresentations(List.of("hero",
+				"criminal",
+				"citizen"));
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = mocks.createKeycloakClientResourceMock();
+		RealmResource realmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientResource,
+				assignedServiceAccountRoleMappings,
+				serviceAccountRealmRoleMappings);
+
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(List.of("HERO",
+				"CRIMINAL"));
+
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+
+		// Act
+		List<RoleRepresentation> actualAssignedRolesToRemove = serviceAccountRoles.findAssignedRolesToRemoveWith(
+				realmResource,
+				k8sClientResourceDefinition,
+				SOME_CLIENT_UUID);
+
+		// Assert
+		assertThat(actualAssignedRolesToRemove).isEmpty();
+	}
+
+	@Test
+	public void noRoleFoundForRemovalWhenUpperCaseRoleNamesEqualGivenLowerCaseRoleNames() {
+		// Arrange
+		List<RoleRepresentation> assignedServiceAccountRoleMappings = testObjects.toRoleRepresentations(List
+				.of("HERO", "CRIMINAL"));
+		List<RoleRepresentation> serviceAccountRealmRoleMappings = testObjects.toRoleRepresentations(List.of(
+				"HERO",
+				"CRIMINAL",
+				"CITIZEN"));
+		org.keycloak.admin.client.resource.ClientResource keycloakClientSourceResource = mocks.createKeycloakClientResourceMock();
+		RealmResource realmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientSourceResource,
+				assignedServiceAccountRoleMappings,
+				serviceAccountRealmRoleMappings);
+
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(List.of("hero",
+				"criminal"));
+
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+
+		// Act
+		List<RoleRepresentation> actualAssignedRolesToRemove = serviceAccountRoles.findAssignedRolesToRemoveWith(
+				realmResource,
+				k8sClientResourceDefinition,
+				SOME_CLIENT_UUID);
+
+		// Assert
+		assertThat(actualAssignedRolesToRemove).isEmpty();
+	}
+
+	@Test
+	public void rolesWithLowerCaseNamesAreFoundForRemovalWhenGivenWithUpperCaseNames() {
+		// Arrange
+		List<RoleRepresentation> assignedServiceAccountRoleMappings = testObjects.toRoleRepresentations(List
+				.of("hero", "criminal"));
+		List<RoleRepresentation> serviceAccountRealmRoleMappings = testObjects.toRoleRepresentations(List.of(
+				"hero",
+				"criminal"));
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = mocks.createKeycloakClientResourceMock();
+		RealmResource keycloakRealmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientResource,
+				assignedServiceAccountRoleMappings,
+				serviceAccountRealmRoleMappings);
+
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(List.of("HERO"));
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+
+		var expectedAssignedServiceAccountRoleToRemove = new RoleRepresentation();
+		expectedAssignedServiceAccountRoleToRemove.setName("criminal");
+
+		// Act
+		List<RoleRepresentation> actualServiceAccountRoleMappingsToRemove = serviceAccountRoles.findAssignedRolesToRemoveWith(
+				keycloakRealmResource,
+				k8sClientResourceDefinition,
+				SOME_CLIENT_UUID);
+
+		// Assert
+		assertThat(actualServiceAccountRoleMappingsToRemove)
+				.usingRecursiveFieldByFieldElementComparator()
+				.containsExactly(expectedAssignedServiceAccountRoleToRemove);
+	}
+
+	@Test
+	public void rolesWithUpperCaseNamesAreFoundForRemovalWhenGivenWithLowerCaseName() {
+		// Arrange
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = mocks.createKeycloakClientResourceMock();
+		List<RoleRepresentation> assignedServiceAccountRoleMappings = testObjects.toRoleRepresentations(List
+				.of("HERO", "CRIMINAL"));
+		List<RoleRepresentation> serviceAccountRealmRoleMappings = testObjects.toRoleRepresentations(List.of(
+				"HERO",
+				"CRIMINAL",
+				"CITIZEN"));
+		RealmResource keycloakRealmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientResource,
+				assignedServiceAccountRoleMappings,
+				serviceAccountRealmRoleMappings);
+
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(List.of("hero"));
+		var expectedServiceAccountRoleRepresentationToRemove = new RoleRepresentation();
+		expectedServiceAccountRoleRepresentationToRemove.setName("CRIMINAL");
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+
+		// Act
+		List<RoleRepresentation> actualAssignedServiceAccountRolesToRemove = serviceAccountRoles.findAssignedRolesToRemoveWith(
+				keycloakRealmResource,
+				k8sClientResourceDefinition,
+				SOME_CLIENT_UUID);
+
+		// Assert
+		assertThat(actualAssignedServiceAccountRolesToRemove)
+				.usingRecursiveFieldByFieldElementComparator()
+				.containsExactly(expectedServiceAccountRoleRepresentationToRemove);
+	}
+
+	@Test
+	public void rolesWithLowerCaseNamesAreFoundToAssignWhenGivenWithUpperCaseName() {
+		// Arrange
+		List<RoleRepresentation> assignedServiceAccountRoleMappings = testObjects.toRoleRepresentations(List
+				.of("citizen"));
+		List<RoleRepresentation> serviceAccountRealmRoleMappings = testObjects.toRoleRepresentations(List.of(
+				"hero",
+				"citizen",
+				"criminal"));
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = mocks.createKeycloakClientResourceMock();
+		RealmResource keycloakRealmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientResource,
+				assignedServiceAccountRoleMappings,
+				serviceAccountRealmRoleMappings);
+
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(List.of("CITIZEN",
+				"HERO"));
+		var expectedServiceAccountRoleToAssign = new RoleRepresentation();
+		expectedServiceAccountRoleToAssign.setName("hero");
+
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+
+		// Act
+		List<RoleRepresentation> actualServiceAccountRoleMappingsToAssign = serviceAccountRoles.findRolesToAssignWith(
+				keycloakRealmResource,
+				k8sClientResourceDefinition,
+				SOME_CLIENT_UUID);
+
+		// Assert
+		assertThat(actualServiceAccountRoleMappingsToAssign)
+				.usingRecursiveFieldByFieldElementComparator()
+				.containsExactly(expectedServiceAccountRoleToAssign);
+	}
+
+	@Test
+	public void rolesWithUpperCaseNamesAreFoundToAssignWhenGivenWithLowerCaseNames() {
+		// Arrange
+		List<RoleRepresentation> assignedServiceAccountRoleMappings = testObjects.toRoleRepresentations(List
+				.of("CITIZEN"));
+		List<RoleRepresentation> serviceAccountRealmRoleMappings = testObjects.toRoleRepresentations(List.of(
+				"HERO",
+				"CITIZEN",
+				"CRIMINAL"));
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = mocks.createKeycloakClientResourceMock();
+		RealmResource keycloakRealmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientResource,
+				assignedServiceAccountRoleMappings,
+				serviceAccountRealmRoleMappings);
+
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(List.of("citizen",
+				"hero"));
+		var expectedServiceAccountRoleToAssign = new RoleRepresentation();
+		expectedServiceAccountRoleToAssign.setName("HERO");
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+
+		// Act
+		List<RoleRepresentation> actualServiceAccountRoleMappingsToAssign = serviceAccountRoles.findRolesToAssignWith(
+				keycloakRealmResource,
+				k8sClientResourceDefinition,
+				SOME_CLIENT_UUID);
+
+		// Assert
+		assertThat(actualServiceAccountRoleMappingsToAssign)
+				.usingRecursiveFieldByFieldElementComparator()
+				.containsExactly(expectedServiceAccountRoleToAssign);
+	}
+
+	@Test
+	public void noRolesFoundToAssignWhenNoRoleExistWithGivenName() {
+		List<RoleRepresentation> serviceAccountRealmRolesMappings = testObjects.toRoleRepresentations(List.of(
+				"HERO",
+				"CITIZEN"));
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = mocks.createKeycloakClientResourceMock();
+		RealmResource keycloakRealmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientResource,
+				Collections.emptyList(),
+				serviceAccountRealmRolesMappings);
+
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(List.of("CRIMINAL"));
+
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+
+		// Act
+		List<RoleRepresentation> actualServiceAccountRoleMappingsToAssign = serviceAccountRoles.findRolesToAssignWith(
+				keycloakRealmResource,
+				k8sClientResourceDefinition,
+				SOME_CLIENT_UUID);
+
+		// Assert
+		assertThat(actualServiceAccountRoleMappingsToAssign)
+				.isEmpty();
+	}
+
+	@Test
+	public void rolesWithLowerCaseNameAreNotFoundForCreationWhenAlreadyExistentWithUpperCaseNames() {
+		// Arrange
+		List<RoleRepresentation> serviceAccountRealmRoleMappings = testObjects.toRoleRepresentations(List.of(
+				"CITIZEN",
+				"HERO"));
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = mocks.createKeycloakClientResourceMock();
+		RealmResource keycloakRealmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientResource,
+				Collections.emptyList(),
+				serviceAccountRealmRoleMappings);
+
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(List.of("hero",
+				"citizen"));
+
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+
+		// Act
+		List<RoleRepresentation> actualServiceAccountRealmRolesMappingsToCreate = serviceAccountRoles.findRequestedRolesToCreateWith(
+				keycloakRealmResource,
+				k8sClientResourceDefinition);
+
+		// Assert
+		assertThat(actualServiceAccountRealmRolesMappingsToCreate).isEmpty();
+	}
+
+	@Test
+	public void rolesWithUpperCaseNameAreNotFoundForCreationWhenAlreadyExistentWithLowerCaseNames() {
+		List<RoleRepresentation> serviceAccountRealmRoleMappings = testObjects.toRoleRepresentations(List.of(
+				"citizen",
+				"hero"));
+
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = mocks.createKeycloakClientResourceMock();
+		RealmResource keycloakRealmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientResource,
+				Collections.emptyList(),
+				serviceAccountRealmRoleMappings);
+
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(List.of("CITIZEN",
+				"HERO"));
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+
+		// Act
+		List<RoleRepresentation> actualServiceAccountRealmRoleMappinsToCreate = serviceAccountRoles.findRequestedRolesToCreateWith(
+				keycloakRealmResource,
+				k8sClientResourceDefinition);
+
+		// Assert
+		assertThat(actualServiceAccountRealmRoleMappinsToCreate).isEmpty();
+	}
+
+	@Test
+	public void rolesGivenWithNamesAreFoundToBeCreatedWhenMissingInRealm() {
+		// Arrange
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = mocks.createKeycloakClientResourceMock();
+		RealmResource keycloakRealmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientResource,
+				Collections.emptyList(),
+				Collections.emptyList());
+
+		List<String> serviceAccountRoleNames = List.of("HERO", "citizen", "CriMInaL");
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(serviceAccountRoleNames);
+
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+		List<RoleRepresentation> expectedServiceAccountRolesToCreate = serviceAccountRoleNames.stream()
+				.map(serviceAccountRoles::createRoleRepresentation)
+				.collect(Collectors.toList());
+		// Act
+		List<RoleRepresentation> actualServiceAccountRealmRolesToCreate = serviceAccountRoles.findRequestedRolesToCreateWith(
+				keycloakRealmResource,
+				k8sClientResourceDefinition);
+
+		// Assert
+		assertThat(actualServiceAccountRealmRolesToCreate)
+				.usingRecursiveFieldByFieldElementComparator()
+				.containsExactlyElementsOf(expectedServiceAccountRolesToCreate);
+	}
+
+	@Test
+	public void noRoleIsFoundForCreationWhenGivenRolesAreAssigned() {
+		List<String> serviceAccountRealmRoleNames = List.of("HERO", "CITIZEN", "police_president");
+		List<RoleRepresentation> serviceAccountRealmRoleMappings = testObjects.toRoleRepresentations(
+				serviceAccountRealmRoleNames);
+
+		org.keycloak.admin.client.resource.ClientResource keycloakClientResource = mocks.createKeycloakClientResourceMock();
+		RealmResource keycloakRealmResource = mocks.createKeycloakRealmResourceMockWith(keycloakClientResource,
+				serviceAccountRealmRoleMappings,
+				serviceAccountRealmRoleMappings);
+
+		ClientResource k8sClientResourceDefinition = testObjects.createK8sClientResourceWith(List.of("HEro",
+				"citizen",
+				"POLICE_president"));
+		var serviceAccountRoles = new ServiceAccountRoleAssignment();
+
+		// Act
+		List<RoleRepresentation> actualServiceAccountRoleMappingsToCreate = serviceAccountRoles.findRequestedRolesToCreateWith(
+				keycloakRealmResource, k8sClientResourceDefinition);
+
+		// Assert
+		assertThat(actualServiceAccountRoleMappingsToCreate).isEmpty();
+	}
+}

--- a/src/test/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentTestObjects.java
+++ b/src/test/java/com/kiwigrid/keycloak/controller/client/ServiceAccountRoleAssignmentTestObjects.java
@@ -1,0 +1,49 @@
+package com.kiwigrid.keycloak.controller.client;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RoleMappingResource;
+import org.keycloak.admin.client.resource.RoleScopeResource;
+import org.keycloak.admin.client.resource.RolesResource;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.representations.idm.MappingsRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+
+public class ServiceAccountRoleAssignmentTestObjects {
+
+	List<RoleRepresentation> toRoleRepresentations(
+			List<String> givenServiceAccountRoleNames)
+	{
+		return givenServiceAccountRoleNames
+				.stream()
+				.map(this::toRoleRepresentation)
+				.collect(Collectors.toList());
+	}
+
+	private RoleRepresentation toRoleRepresentation(String nameName) {
+		var keycloakRoleRepresentation = new RoleRepresentation();
+		keycloakRoleRepresentation.setName(nameName);
+		return keycloakRoleRepresentation;
+	}
+
+	com.kiwigrid.keycloak.controller.client.ClientResource createK8sClientResourceWith(List<String> rolesToAssign) {
+		var clientResourceSpecification = new com.kiwigrid.keycloak.controller.client.ClientResource.ClientResourceSpec();
+		clientResourceSpecification.setServiceAccountRealmRoles(rolesToAssign);
+
+		var clientResource = new com.kiwigrid.keycloak.controller.client.ClientResource();
+		clientResource.setSpec(clientResourceSpecification);
+		return clientResource;
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Keycloak is case sensitive on role names, but the keycloak-controller isn't. This PR let the client controller synchronize service account roles ignoring role name case.


#### Which issue this PR fixes
No issue was reported

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://developercertificate.org) signed
- [ ] New stuff is documented in the README.md
